### PR TITLE
Reduce frontscript size but still big for web

### DIFF
--- a/front-script/package.json
+++ b/front-script/package.json
@@ -5,7 +5,7 @@
   "main": "src/main/index.js",
   "scripts": {
     "start": "parcel ./public/index.html -p 8081",
-    "build": "parcel build ./public/index.html  --out-file frontscript.html"
+    "build": "NODE_ENV=production parcel build ./public/index.html  --out-file frontscript.html"
   },
   "contributors": [
     {

--- a/front-script/src/controllers/firebase/index.js
+++ b/front-script/src/controllers/firebase/index.js
@@ -1,4 +1,6 @@
-import * as firebase from 'firebase';
+import firebase from 'firebase/app';
+import 'firebase/auth';
+import 'firebase/functions';
 import { getClientInfo } from '../../utils';
 
 /**
@@ -17,7 +19,7 @@ const app = firebase.initializeApp({
 	projectId: process.env.FB_PROJECTID,
 	storageBucket: process.env.FB_STORAGEBUCKET,
 	messagingSenderId: process.env.FB_PROJECTID
-});
+}, 'yakchat-frontscript');
 
 const channel = 'testing';
 var functions = app.functions();


### PR DESCRIPTION
Closes #20 

Build with Parcel and remove the whole firebase's SDK and just use the components that we going to use only... give me a script of `427.06KB`.
![parcel_build](https://user-images.githubusercontent.com/1518548/54154430-e34a3400-440f-11e9-9017-e12a40372a1f.png)

We need to remove more components from the front script ... this kind of resolve the problem but i believe 400KB is still big for the web. I going to need @oreyes1991 involve to remove the size of the script ... maybe we can delete dependecies and emulate the behavior with native code and avoid the payload of the dependecy.

Also firbase auth component is really big as you can see in the following image:
![fb_dep](https://user-images.githubusercontent.com/1518548/54154677-75523c80-4410-11e9-892c-e433daaf1011.png)
